### PR TITLE
Enables running briefcase as root on Linux

### DIFF
--- a/changes/416.bugfix.rst
+++ b/changes/416.bugfix.rst
@@ -1,0 +1,2 @@
+Enables running briefcase as root on Linux.
+

--- a/{{ cookiecutter.formal_name }}/Dockerfile
+++ b/{{ cookiecutter.formal_name }}/Dockerfile
@@ -35,5 +35,6 @@ RUN python${PY_VERSION} -m pip install --upgrade wheel
 ARG HOST_UID
 ARG HOST_GID
 RUN groupadd --gid $HOST_GID briefcase || true
-RUN useradd --uid $HOST_UID --gid $HOST_GID brutus --home /home/brutus
+# In case briefcase is run as root, user brutus will reuse UID:GID of containers root account (beeware/briefcase#416)
+RUN useradd --non-unique --uid $HOST_UID --gid $HOST_GID brutus --home /home/brutus
 USER brutus


### PR DESCRIPTION
Fixes part of of the issues described in https://github.com/beeware/briefcase/issues/416, the rest has to be implemented in briefcase itself.
In particular this fixes the Dockerfile so that a full briefcase build cycle (new, create, build) can be executed as root.