### PR TITLE
[fix][dependency] add pip constraint "pycairo<1.20"

### DIFF
--- a/{{ cookiecutter.formal_name }}/Dockerfile
+++ b/{{ cookiecutter.formal_name }}/Dockerfile
@@ -30,6 +30,7 @@ RUN python${PY_VERSION} -m ensurepip
 RUN python${PY_VERSION} -m pip install --upgrade pip
 RUN python${PY_VERSION} -m pip install --upgrade setuptools
 RUN python${PY_VERSION} -m pip install --upgrade wheel
+RUN CONSTRAINTS="/constraints.txt"; pip config --global set global.constraint $CONSTRAINTS; echo "pycairo<1.20" > $CONSTRAINTS
 
 # Ensure Docker user UID:GID matches host user UID:GID (beeware/briefcase#403)
 ARG HOST_UID


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Adds a global pip constraint "pycairo<1.20" to the Ubuntu 16.04 based docker image

tested locally, ONLY in scope of the [Beeware's tutorial example](https://docs.beeware.org/en/latest/index.html) on:
- venv python3.8
- host ubuntu 18.04

so I'm not sure about any further side effects.


<!--- What problem does this change solve? -->
Beeware's tutorial example using Ubuntu 16.04 docker image
got broken starting on pycairo>=1.20.

Starting on pycairo == 1.20, it requires cairo >= 1.15.10,
while Ubuntu 16.04 has cairo 1.14.xx
(see changelog https://pycairo.readthedocs.io/en/latest/changelog.html)

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
