### PR TITLE
fix missing ensurepip on python 3.6 build

### DIFF
--- a/{{ cookiecutter.formal_name }}/Dockerfile
+++ b/{{ cookiecutter.formal_name }}/Dockerfile
@@ -28,8 +28,18 @@ RUN apt-get update -y && \
         python${PY_VERSION}-venv \
         ${SYSTEM_REQUIRES}
 
-# Install (and update) pip, disabling the global cache
-RUN python${PY_VERSION} -m ensurepip
+# Install (and update) pip, disabling the global cache. Ubuntu python packages
+# disable ensurepip, which the deadsnakes PPA re-enables if python*-venv is
+# installed, but the deadsnakes PPA only provides packages for python version
+# unavailable in the selected Ubuntu release. Thus, we use the system
+# python3-pip package for those python versions.
+RUN if [ ${PY_VERSION} != 3.6 ]; then \
+        python${PY_VERSION} -m ensurepip; \
+    else \
+        apt-get install -y python3-pip; \
+    fi
+# Upgrade to at least pip-10.0.0 when the 'config' subcommand was added
+RUN python${PY_VERSION} -m pip install --upgrade pip>=10.0.0
 RUN python${PY_VERSION} -m pip config set global.cache-dir false
 RUN python${PY_VERSION} -m pip install --upgrade pip
 RUN python${PY_VERSION} -m pip install --upgrade setuptools


### PR DESCRIPTION
This block comment explains most of it:

```
# Install (and update) pip, disabling the global cache. Ubuntu python packages
# disable ensurepip, which the deadsnakes PPA re-enables if python*-venv is
# installed, but the deadsnakes PPA only provides packages for python version
# unavailable in the selected Ubuntu release. Thus, we use the system
# python3-pip package for those python versions.
```

For reference, this is the error message `python3.6 -m ensurepip` gives:

```
ensurepip is disabled in Debian/Ubuntu for the system python.

Python modules for the system python are usually handled by dpkg and apt-get.

    apt-get install python-<module name>

Install the python-pip package to use pip itself.  Using pip together
with the system python might have unexpected results for any system installed
module, so use it on your own risk, or make sure to only use it in virtual
environments.
```

I've only tested on 3.6 so far, as that's all I have on my machine right at the moment.