### PR TITLE
fix missing ensurepip on python 3.6 build

### DIFF
--- a/{{ cookiecutter.formal_name }}/Dockerfile
+++ b/{{ cookiecutter.formal_name }}/Dockerfile
@@ -20,24 +20,23 @@ RUN apt-get update -y && \
         ca-certificates
 RUN apt-add-repository ppa:deadsnakes/ppa
 
-# Install git, Python, and any packages required
+# Install git, Python, and any packages required. Ubuntu python packages
+# disable ensurepip, which the deadsnakes PPA re-enables if python*-venv is
+# installed, but the deadsnakes PPA only provides packages for python version
+# unavailable in the selected Ubuntu release. Thus, we use the system
+# python3-pip package for those python versions.
 RUN apt-get update -y && \
     apt-get install -y \
         git \
         python${PY_VERSION}-dev \
         python${PY_VERSION}-venv \
+        python3-pip \
         ${SYSTEM_REQUIRES}
 
-# Install (and update) pip, disabling the global cache. Ubuntu python packages
-# disable ensurepip, which the deadsnakes PPA re-enables if python*-venv is
-# installed, but the deadsnakes PPA only provides packages for python version
-# unavailable in the selected Ubuntu release. Thus, we use the system
-# python3-pip package for those python versions.
-RUN apt-get install -y python3-pip
-# Upgrade to at least pip-10.0.0 when the 'config' subcommand was added
-RUN python${PY_VERSION} -m pip install --upgrade pip>=10.0.0
-RUN python${PY_VERSION} -m pip config set global.cache-dir false
+# Install (and update) pip, disabling the global cache. We upgrade pip *before*
+# disabling the system cache because pip 9 predates the config subcommand.
 RUN python${PY_VERSION} -m pip install --upgrade pip
+RUN python${PY_VERSION} -m pip config set global.cache-dir false
 RUN python${PY_VERSION} -m pip install --upgrade setuptools
 RUN python${PY_VERSION} -m pip install --upgrade wheel
 

--- a/{{ cookiecutter.formal_name }}/Dockerfile
+++ b/{{ cookiecutter.formal_name }}/Dockerfile
@@ -28,8 +28,14 @@ RUN apt-get update -y && \
         python${PY_VERSION}-venv \
         ${SYSTEM_REQUIRES}
 
-# Install (and update) pip, disabling the global cache
-RUN python${PY_VERSION} -m ensurepip
+# Install (and update) pip, disabling the global cache. Ubuntu python packages
+# disable ensurepip, which the deadsnakes PPA re-enables if python*-venv is
+# installed, but the deadsnakes PPA only provides packages for python version
+# unavailable in the selected Ubuntu release. Thus, we use the system
+# python3-pip package for those python versions.
+RUN apt-get install -y python3-pip
+# Upgrade to at least pip-10.0.0 when the 'config' subcommand was added
+RUN python${PY_VERSION} -m pip install --upgrade pip>=10.0.0
 RUN python${PY_VERSION} -m pip config set global.cache-dir false
 RUN python${PY_VERSION} -m pip install --upgrade pip
 RUN python${PY_VERSION} -m pip install --upgrade setuptools


### PR DESCRIPTION
This block comment explains most of it:

```
# Install (and update) pip, disabling the global cache. Ubuntu python packages
# disable ensurepip, which the deadsnakes PPA re-enables if python*-venv is
# installed, but the deadsnakes PPA only provides packages for python version
# unavailable in the selected Ubuntu release. Thus, we use the system
# python3-pip package for those python versions.
```

For reference, this is the error message `python3.6 -m ensurepip` gives:

```
ensurepip is disabled in Debian/Ubuntu for the system python.

Python modules for the system python are usually handled by dpkg and apt-get.

    apt-get install python-<module name>

Install the python-pip package to use pip itself.  Using pip together
with the system python might have unexpected results for any system installed
module, so use it on your own risk, or make sure to only use it in virtual
environments.
```

One additional comment about these two lines added in this diff:

``` python
# Upgrade to at least pip-10.0.0 when the 'config' subcommand was added
RUN python${PY_VERSION} -m pip install --upgrade pip>=10.0.0
```

It appears that, according to the Python `NEWS` files, `ensurepip` was updated to install pip-20.1.1 in the following minor versions, which are older than what's in the deadsnakes PPA, thus obviating the need for these two lines to be added to the 3.7, 3.8, or 3.9 branches:

- python 3.7.8
- python 3.8.4
- python 3.9.0

Tested this with my own project on python3.6.