### PR TITLE
3.9

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ Briefcase Linux AppImage Template
 A `Cookiecutter <https://github.com/cookiecutter/cookiecutter/>`__ template for
 building Python apps that will run under Linux, packaged as an AppImage.
 
-**This is the development version of the repository. It contains a template for Python 3.9**.
+**This repository branch contains a template for Python 3.9**.
 Other Python versions are available by cloning other branches of repository.
 
 Using this template

--- a/{{ cookiecutter.formal_name }}/Dockerfile
+++ b/{{ cookiecutter.formal_name }}/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /app
 # Set up Docker build arguments
 ARG PY_VERSION
 ARG SYSTEM_REQUIRES
+ARG DEBIAN_FRONTEND=noninteractive
 
 # Install the deadsnakes PPA so we can get arbitrary Python versions
 RUN apt-get update -y && \


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Added ARG DEBIAN_FRONTEND=noninteractive to Dockerfile
<!--- What problem does this change solve? -->
briefcase create linux fails on Fedora as the docker build pauses waiting for the user to select a timezone, which is not possible to do. Adding this entry prevents any user interaction, so the create is successful.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
