### PR TITLE
[Fix for `briefcase create`] Set DEBIAN_FRONTEND env-var so tzdata installs itself properly

### DIFF
--- a/{{ cookiecutter.formal_name }}/Dockerfile
+++ b/{{ cookiecutter.formal_name }}/Dockerfile
@@ -10,6 +10,9 @@ WORKDIR /app
 ARG PY_VERSION
 ARG SYSTEM_REQUIRES
 
+# Make sure installation of tzdata is non-interactive
+ENV DEBIAN_FRONTEND="noninteractive"
+
 # Install the deadsnakes PPA so we can get arbitrary Python versions
 RUN apt-get update -y && \
     apt-get install -y \


### PR DESCRIPTION
<!--- Describe your changes in detail -->
If `DEBIAN_FRONTEND` is set to `noninteractive` then `tzdata`, which governs timezones, is set automatically when `briefcase create` makes a new Docker environment.
<!--- What problem does this change solve? -->
Getting stuck when running `briefcase create`
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
(briefcase) Issue No. 567

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ Check ] All new features have been tested
- [ Check ] All new features have been documented
- [ ] I have read the **CONTRIBUTING.md** file
- [ Check ] I will abide by the code of conduct
