### PR TITLE
Add StartupWMClass to .desktop file.

### DIFF
--- a/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}.AppDir/{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.desktop
+++ b/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}.AppDir/{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.desktop
@@ -5,3 +5,4 @@ Exec={{ cookiecutter.bundle }}.{{ cookiecutter.app_name }} %F
 Icon={{ cookiecutter.app_name }}
 Categories=Utility;
 Comment={{ cookiecutter.description }}
+StartupWMClass={{ cookiecutter.formal_name }}


### PR DESCRIPTION
Adds `StartupWMClass` to .desktop file. This is required to associate app's window to app's .desktop file. Partially fixes https://github.com/beeware/briefcase/issues/661.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
