### PR TITLE
Fixes #13 - Ensure that the brutus user directory is owned by brutus

### DIFF
--- a/{{ cookiecutter.formal_name }}/Dockerfile
+++ b/{{ cookiecutter.formal_name }}/Dockerfile
@@ -45,4 +45,9 @@ ARG HOST_UID
 ARG HOST_GID
 RUN groupadd --non-unique --gid $HOST_GID briefcase
 RUN useradd --non-unique --uid $HOST_UID --gid $HOST_GID brutus --home /home/brutus
+
+# Create the brutus home directory; ensure that it is owned by brutus.
+RUN mkdir -p /home/brutus && chown brutus:briefcase /home/brutus
+
+# Use the brutus user for operations in the container
 USER brutus


### PR DESCRIPTION
Ensure that the ~brutus folder exists, and is owned by Brutus.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
