### PR TITLE
Dockerfile Streamlining

### DIFF
--- a/{{ cookiecutter.formal_name }}/Dockerfile
+++ b/{{ cookiecutter.formal_name }}/Dockerfile
@@ -6,48 +6,46 @@ FROM ubuntu:18.04
 # Set the working directory
 WORKDIR /app
 
-# Set up Docker build arguments
-ARG PY_VERSION
-ARG SYSTEM_REQUIRES
-
 # Make sure installation of tzdata is non-interactive
-ENV DEBIAN_FRONTEND="noninteractive"
+ENV DEBIAN_FRONTEND="noninteractive" \
+# Disable pip warnings about running as root (pip >= 22.1)
+    PIP_ROOT_USER_ACTION="ignore"
 
 # Install the deadsnakes PPA so we can get arbitrary Python versions
 RUN apt-get update -y && \
-    apt-get install -y \
-        software-properties-common \
-        dirmngr \
-        apt-transport-https \
-        lsb-release \
-        ca-certificates
-RUN apt-add-repository ppa:deadsnakes/ppa
+    apt-get install --no-install-recommends -y software-properties-common && \
+    apt-add-repository ppa:deadsnakes/ppa
 
-# Install git, Python, and any packages required
+# Python version for image
+ARG PY_VERSION
+
+# Install git, file (for linuxdeploy), Python, and any packages required for the app
 RUN apt-get update -y && \
-    apt-get install -y \
+    apt-get install --no-install-recommends -y \
         git \
+        file \
         python${PY_VERSION}-dev \
-        python${PY_VERSION}-venv \
-        ${SYSTEM_REQUIRES}
+        python${PY_VERSION}-venv
 
 # Install (and update) pip, disabling the global cache
-RUN python${PY_VERSION} -m ensurepip
-RUN python${PY_VERSION} -m pip config set global.cache-dir false
-RUN python${PY_VERSION} -m pip install --upgrade pip
-RUN python${PY_VERSION} -m pip install --upgrade setuptools
-RUN python${PY_VERSION} -m pip install --upgrade wheel
+RUN python${PY_VERSION} -m ensurepip && \
+    python${PY_VERSION} -m pip config set global.cache-dir false && \
+    python${PY_VERSION} -m pip install --upgrade pip && \
+    python${PY_VERSION} -m pip install --upgrade setuptools wheel
 
 # Ensure Docker user UID:GID matches host user UID:GID (beeware/briefcase#403)
 # Use --non-unique to avoid problems when the UID:GID of the host user
 # collides with entries provided by the Docker container.
 ARG HOST_UID
 ARG HOST_GID
-RUN groupadd --non-unique --gid $HOST_GID briefcase
-RUN useradd --non-unique --uid $HOST_UID --gid $HOST_GID brutus --home /home/brutus
+RUN groupadd --non-unique --gid $HOST_GID briefcase && \
+    useradd --non-unique --uid $HOST_UID --gid $HOST_GID brutus --home /home/brutus && \
+    mkdir -p /home/brutus && chown brutus:briefcase /home/brutus
 
-# Create the brutus home directory; ensure that it is owned by brutus.
-RUN mkdir -p /home/brutus && chown brutus:briefcase /home/brutus
+# Install system packages required by app
+ARG SYSTEM_REQUIRES
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y ${SYSTEM_REQUIRES}
 
 # Use the brutus user for operations in the container
 USER brutus


### PR DESCRIPTION
## Changes
 - Disable pip progress bar and warning about running as root
 - Disable apt-get installing (recommended) packages that aren't strict dependents
 - Limit the number of RUN calls so less intermediate image layers are created

## Notes
Interestingly, `file` doesn't exist in the base ubuntu-18.04 image....but `linuxdeploy` explicitly requires it. It was getting pulled in as a recommended package previously.

Probably ideally this is all one RUN statement since none of these intermediate layers are especially useful...but readability and maintainability is sacrificed at some point.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct