### PR TITLE
Add linuxdeploy plugins to PATH

### DIFF
--- a/{{ cookiecutter.formal_name }}/Dockerfile
+++ b/{{ cookiecutter.formal_name }}/Dockerfile
@@ -49,3 +49,6 @@ RUN apt-get update -y && \
 
 # Use the brutus user for operations in the container
 USER brutus
+
+# Add path for linuxdeploy plugins
+ENV PATH="/home/brutus/.briefcase/tools/linuxdeploy_plugins:${PATH}"


### PR DESCRIPTION
This PR goes along with https://github.com/beeware/briefcase/pull/756. In order for linuxdeploy to pick up plugins, they either need to be next to the linuxdeploy AppImage or in the PATH. This PR adds the plugin directory to the PATH.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
