### PR TITLE
Run App with unbuffered Python stdout/sterr

### DIFF
--- a/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}.AppDir/usr/bin/{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}
+++ b/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}.AppDir/usr/bin/{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}
@@ -4,4 +4,4 @@ export APPDIR=$(dirname "$0")
 export PYTHONPATH=$APPDIR/usr/app:$APPDIR/usr/app_packages
 # echo "PYTHONPATH IS $PYTHONPATH"
 # echo "PATH IS $PATH"
-$APPDIR/usr/bin/python3 -s -c 'import runpy, sys; sys.path.pop(0); runpy.run_module("{{ cookiecutter.module_name }}", run_name="__main__", alter_sys=True)' "$@"
+$APPDIR/usr/bin/python3 -u -s -c 'import runpy, sys; sys.path.pop(0); runpy.run_module("{{ cookiecutter.module_name }}", run_name="__main__", alter_sys=True)' "$@"


### PR DESCRIPTION
Similar to beeware/briefcase#892, this change runs Python from the AppImage with unbuffered output.

~~I'm proposing this assuming it is desired. I'm not sure this has meaningful negative consequences...except perhaps worse performance if an app is sending a lot of data to stdout/err.~~

edit: after reviewing the other platforms, it definitely appears unbuffered output is desired.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
