### PR TITLE
Allow injection of arbitrary Dockerfile content.

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -6,6 +6,7 @@
     "url": "https://example.com",
     "description": "Short description of app",
     "python_version": "3.X.0",
+    "dockerfile_extra_content": "",
     "_extensions": [
         "briefcase.integrations.cookiecutter.PythonVersionExtension"
     ]

--- a/{{ cookiecutter.formal_name }}/Dockerfile
+++ b/{{ cookiecutter.formal_name }}/Dockerfile
@@ -49,3 +49,6 @@ RUN apt-get update -y && \
 
 # Use the brutus user for operations in the container
 USER brutus
+
+# ========== START USER PROVIDED CONTENT ==========
+{{ cookiecutter.dockerfile_extra_content }}


### PR DESCRIPTION
The existing Dockerfile allows for very specific customisations, such as installation of additional system packages. However, sometimes that is insufficient.

For example, installing the Python `cryptography` package requires a Rust compiler, but it is not possible to install ``rustc`` 
using `apt-get`; you need to run a `rust-up.sh` script.

This template update allows for an end-user to inject arbitrary Dockerfile content into their project configuration. See beeware/Python-support-testbed#5 for an example of this in use.

Fixes beeware/briefcase#886.
Refs beeware/Python-support-testbed#5

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x]  I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
