### PR TITLE
Add support for the BRIEFCASE_MAIN_MODULE testing override.

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -6,6 +6,7 @@
     "url": "https://example.com",
     "description": "Short description of app",
     "python_version": "3.X.0",
+    "dockerfile_extra_content": "",
     "_extensions": [
         "briefcase.integrations.cookiecutter.PythonVersionExtension"
     ]

--- a/{{ cookiecutter.formal_name }}/Dockerfile
+++ b/{{ cookiecutter.formal_name }}/Dockerfile
@@ -27,12 +27,6 @@ RUN apt-get update -y && \
         python${PY_VERSION}-dev \
         python${PY_VERSION}-venv
 
-# Install (and update) pip, disabling the global cache
-RUN python${PY_VERSION} -m ensurepip && \
-    python${PY_VERSION} -m pip config set global.cache-dir false && \
-    python${PY_VERSION} -m pip install --upgrade pip && \
-    python${PY_VERSION} -m pip install --upgrade setuptools wheel
-
 # Ensure Docker user UID:GID matches host user UID:GID (beeware/briefcase#403)
 # Use --non-unique to avoid problems when the UID:GID of the host user
 # collides with entries provided by the Docker container.
@@ -42,7 +36,13 @@ RUN groupadd --non-unique --gid $HOST_GID briefcase && \
     useradd --non-unique --uid $HOST_UID --gid $HOST_GID brutus --home /home/brutus && \
     mkdir -p /home/brutus && chown brutus:briefcase /home/brutus
 
-# Install system packages required by app
+# Ensure pip is available; do this as the brutus user
+# to ensure that the pip cache is created user-readable.
+USER brutus
+RUN python${PY_VERSION} -m ensurepip
+
+# As root, Install system packages required by app
+USER root
 ARG SYSTEM_REQUIRES
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y ${SYSTEM_REQUIRES}

--- a/{{ cookiecutter.formal_name }}/Dockerfile
+++ b/{{ cookiecutter.formal_name }}/Dockerfile
@@ -49,3 +49,6 @@ RUN apt-get update -y && \
 
 # Use the brutus user for operations in the container
 USER brutus
+
+# ========== START USER PROVIDED CONTENT ==========
+{{ cookiecutter.dockerfile_extra_content }}

--- a/{{ cookiecutter.formal_name }}/briefcase.toml
+++ b/{{ cookiecutter.formal_name }}/briefcase.toml
@@ -3,7 +3,12 @@
 app_path = "{{ cookiecutter.formal_name }}.AppDir/usr/app"
 app_packages_path = "{{ cookiecutter.formal_name }}.AppDir/usr/app_packages"
 support_path = "{{ cookiecutter.formal_name }}.AppDir/usr"
-{{ {"3.8": "support_revision = 7", "3.9": "support_revision = 5", "3.10": "support_revision = 4", "3.11": "support_revision = 1"}.get(cookiecutter.python_version|py_tag, "") }}
+{{ {
+    "3.8": "support_revision = 7",
+    "3.9": "support_revision = 5",
+    "3.10": "support_revision = 4",
+    "3.11": "support_revision = 1"
+}.get(cookiecutter.python_version|py_tag, "") }}
 
 icon.16 = "{{ cookiecutter.formal_name }}.AppDir/usr/share/icons/hicolor/16x16/apps/{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.png"
 icon.32 = "{{ cookiecutter.formal_name }}.AppDir/usr/share/icons/hicolor/32x32/apps/{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.png"

--- a/{{ cookiecutter.formal_name }}/briefcase.toml
+++ b/{{ cookiecutter.formal_name }}/briefcase.toml
@@ -7,7 +7,7 @@ support_path = "{{ cookiecutter.formal_name }}.AppDir/usr"
     "3.8": "support_revision = 7",
     "3.9": "support_revision = 5",
     "3.10": "support_revision = 4",
-    "3.11": "support_revision = 1"
+    "3.11": "support_revision = 2",
 }.get(cookiecutter.python_version|py_tag, "") }}
 
 icon.16 = "{{ cookiecutter.formal_name }}.AppDir/usr/share/icons/hicolor/16x16/apps/{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.png"

--- a/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}.AppDir/usr/bin/{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}
+++ b/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}.AppDir/usr/bin/{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}
@@ -1,7 +1,11 @@
 #!/bin/bash
 export APPDIR=$(dirname "$0")
-# echo "APPDIR IS $APPDIR"
-export PYTHONPATH=$APPDIR/usr/app:$APPDIR/usr/app_packages
-# echo "PYTHONPATH IS $PYTHONPATH"
-# echo "PATH IS $PATH"
-$APPDIR/usr/bin/python3 -u -s -c 'import runpy, sys; sys.path.pop(0); runpy.run_module("{{ cookiecutter.module_name }}", run_name="__main__", alter_sys=True)' "$@"
+# echo "APPDIR=${APPDIR}"
+export PYTHONPATH=${APPDIR}/usr/app:${APPDIR}/usr/app_packages
+# echo "PYTHONPATH=${PYTHONPATH}"
+# echo "PATH=${PATH}"
+if [[ -z "${BRIEFCASE_MAIN_MODULE}" ]]; then
+    BRIEFCASE_MAIN_MODULE="{{ cookiecutter.module_name }}"
+fi
+# echo "BRIEFCASE_MAIN_MODULE=${BRIEFCASE_MAIN_MODULE}"
+"${APPDIR}/usr/bin/python3" -u -s -c "import runpy, sys; sys.path.pop(0); runpy.run_module('${BRIEFCASE_MAIN_MODULE}', run_name='__main__', alter_sys=True)" "$@"


### PR DESCRIPTION
Modifications to the AppImage template to support testing.

This is primarily adding support for the `BRIEFCASE_MAIN_MODULE` testing override; if the environment contains that environment variable, it will be used in preference to the app's default module name.

Refs beeware/briefcase#962

Builds on #22

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
