### PR TITLE
Use PEP540 UTF-8 mode.

### DIFF
--- a/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}.AppDir/usr/bin/{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}
+++ b/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}.AppDir/usr/bin/{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}
@@ -8,4 +8,4 @@ if [[ -z "${BRIEFCASE_MAIN_MODULE}" ]]; then
     BRIEFCASE_MAIN_MODULE="{{ cookiecutter.module_name }}"
 fi
 # echo "BRIEFCASE_MAIN_MODULE=${BRIEFCASE_MAIN_MODULE}"
-"${APPDIR}/usr/bin/python3" -u -s -c "import runpy, sys; sys.path.pop(0); runpy.run_module('${BRIEFCASE_MAIN_MODULE}', run_name='__main__', alter_sys=True)" "$@"
+"${APPDIR}/usr/bin/python3" -u -s -X utf8 -c "import runpy, sys; sys.path.pop(0); runpy.run_module('${BRIEFCASE_MAIN_MODULE}', run_name='__main__', alter_sys=True)" "$@"


### PR DESCRIPTION
Following beeware/briefcase-macOS-Xcode-template#18, the Python interpreter started by AppImage hasn't been configured to use UTF-8 mode. 

This PR adds the necessary flag to the interpreter at start-up. This wasn't needed to pass CI with the extra test case added by beeware/Python-support-testbed#8 (as most linux systems default to UTF-8 mode); however, this ensures that UTF8 mode will always be enabled.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
