### PR TITLE
Add support to conditionally step down from root

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -10,7 +10,7 @@
     "python_version": "3.X.0",
     "manylinux_image": "",
     "vendor_base": "debian",
-    "use_non_root_user": "True",
+    "use_non_root_user": true,
     "dockerfile_extra_content": "",
     "_extensions": [
         "briefcase.integrations.cookiecutter.PythonVersionExtension"

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -10,6 +10,7 @@
     "python_version": "3.X.0",
     "manylinux_image": "",
     "vendor_base": "debian",
+    "use_non_root_user": "True",
     "dockerfile_extra_content": "",
     "_extensions": [
         "briefcase.integrations.cookiecutter.PythonVersionExtension"

--- a/{{ cookiecutter.format }}/Dockerfile
+++ b/{{ cookiecutter.format }}/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update -y && \
 RUN yum install -y git file
 {%- endif %}
 
-{% if cookiecutter.use_non_root_user == "True" -%}
+{% if cookiecutter.use_non_root_user -%}
 # Ensure Docker user UID:GID matches host user UID:GID (beeware/briefcase#403)
 # Use --non-unique to avoid problems when the UID:GID of the host user
 # collides with entries provided by the Docker container.
@@ -39,7 +39,7 @@ RUN apt-get install --no-install-recommends -y build-essential ${SYSTEM_REQUIRES
 RUN yum install -y gcc make pkgconfig ${SYSTEM_REQUIRES}
 {%- endif %}
 
-{% if cookiecutter.use_non_root_user == "True" -%}
+{% if cookiecutter.use_non_root_user -%}
 # Use the brutus user for operations in the container
 USER brutus
 {%- endif %}

--- a/{{ cookiecutter.format }}/Dockerfile
+++ b/{{ cookiecutter.format }}/Dockerfile
@@ -1,4 +1,4 @@
-{% if cookiecutter.manylinux_image %}
+{% if cookiecutter.manylinux_image -%}
 FROM quay.io/pypa/{{ cookiecutter.manylinux_image }}
 {%- else %}
 # Ubuntu:18.04 based AppImages are for legacy projects
@@ -8,18 +8,19 @@ FROM ubuntu:18.04
 # Set the working directory
 WORKDIR /app
 
-{% if cookiecutter.vendor_base == "debian" %}
+{% if cookiecutter.vendor_base == "debian" -%}
 # Make sure installation of tzdata is non-interactive
 ENV DEBIAN_FRONTEND="noninteractive"
 
 # Install git and file (for linuxdeploy)
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y git file
-{% else %}
+{%- else -%}
 # Install git and file (for linuxdeploy)
 RUN yum install -y git file
-{% endif %}
+{%- endif %}
 
+{% if cookiecutter.use_non_root_user == "True" -%}
 # Ensure Docker user UID:GID matches host user UID:GID (beeware/briefcase#403)
 # Use --non-unique to avoid problems when the UID:GID of the host user
 # collides with entries provided by the Docker container.
@@ -28,17 +29,20 @@ ARG HOST_GID
 RUN groupadd --non-unique --gid $HOST_GID briefcase && \
     useradd --non-unique --uid $HOST_UID --gid $HOST_GID brutus --home /home/brutus && \
     mkdir -p /home/brutus && chown brutus:briefcase /home/brutus
+{%- endif %}
 
 # As root, Install system packages required by app
 ARG SYSTEM_REQUIRES
-{% if cookiecutter.vendor_base == "debian" %}
+{% if cookiecutter.vendor_base == "debian" -%}
 RUN apt-get install --no-install-recommends -y build-essential ${SYSTEM_REQUIRES}
-{% else %}
+{%- else -%}
 RUN yum install -y gcc make pkgconfig ${SYSTEM_REQUIRES}
-{% endif %}
+{%- endif %}
 
+{% if cookiecutter.use_non_root_user == "True" -%}
 # Use the brutus user for operations in the container
 USER brutus
+{%- endif %}
 
 # Configure builds so that clang isn't required, and put the Standalone Python on the build path
 ENV CC="gcc -pthread"


### PR DESCRIPTION
## Changes
- Adds support to conditionally introduce a step down user (i.e. "brutus") in images created from the Dockerfile
- This is required for Docker Desktop and rootless Docker as outlined in beeware/briefcase#1083

BRIEFCASE_REPO: https://github.com/rmartin16/briefcase/
BRIEFCASE_REF: docker-desktop

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
