### PR TITLE
Dockerfile tweaks

### DIFF
--- a/{{ cookiecutter.format }}/Dockerfile
+++ b/{{ cookiecutter.format }}/Dockerfile
@@ -8,6 +8,10 @@ FROM ubuntu:18.04
 # Set the working directory
 WORKDIR /app
 
+# Disable pip's warnings
+ENV PIP_ROOT_USER_ACTION=ignore \
+    PIP_NO_WARN_SCRIPT_LOCATION=0
+
 {% if cookiecutter.vendor_base == "debian" -%}
 # Make sure installation of tzdata is non-interactive
 ENV DEBIAN_FRONTEND="noninteractive"

--- a/{{ cookiecutter.format }}/Dockerfile
+++ b/{{ cookiecutter.format }}/Dockerfile
@@ -28,7 +28,7 @@ ARG HOST_UID
 ARG HOST_GID
 RUN groupadd --non-unique --gid $HOST_GID briefcase && \
     useradd --non-unique --uid $HOST_UID --gid $HOST_GID brutus --home /home/brutus && \
-    mkdir -p /home/brutus && chown brutus:briefcase /home/brutus
+    mkdir -p /home/brutus/.cache/briefcase && chown -R brutus:briefcase /home/brutus
 {%- endif %}
 
 # As root, Install system packages required by app


### PR DESCRIPTION
## Changes
- Since the Briefcase data directory is bind mounted in to the `.cache` directory when `.cache` does not yet exist, Docker assigns `root` as its owner and this can create spurious warnings for applications trying to use `.cache` while building/installing.
- Disable `pip` warnings for installing as `root` and the scripts not in `PATH`

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
