### PR TITLE
Revert bb3f415 since Briefcase no longer mounting to `~/.cache`

### DIFF
--- a/{{ cookiecutter.format }}/Dockerfile
+++ b/{{ cookiecutter.format }}/Dockerfile
@@ -32,7 +32,7 @@ ARG HOST_UID
 ARG HOST_GID
 RUN groupadd --non-unique --gid $HOST_GID briefcase && \
     useradd --non-unique --uid $HOST_UID --gid $HOST_GID brutus --home /home/brutus && \
-    mkdir -p /home/brutus/.cache/briefcase && chown -R brutus:briefcase /home/brutus
+    mkdir -p /home/brutus && chown brutus:briefcase /home/brutus
 {%- endif %}
 
 # As root, Install system packages required by app


### PR DESCRIPTION
bb3f415

BRIEFCASE_REPO:  https://github.com/rmartin16/briefcase/
BRIEFCASE_REF: tools-bind-mount

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct