### PR TITLE
Add updated support packages and CI for Python 3.12.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
         framework: [ "toga", "pyside2", "pyside6", "ppb", "pygame" ]
         exclude:
-          # PySide 2 and 6 don't currently publish binary wheels
-          # that are compatible with Python 3.11 and/or Ubuntu 18.04
+          # PySide 2 doesn't publish binary wheels that are compatible with Python 3.11+
+          # and/or Ubuntu 22.04 (and is unlikely to ever do so.)
           - python-version: "3.11"
             framework: "pyside2"
+          - python-version: "3.12"
+            framework: "pyside2"
+          # PySide 6 doesn't currently publish binary wheels
+          # that are compatible with Python 3.11+ and/or Ubuntu 22.04
           - python-version: "3.11"
+            framework: "pyside6"
+          - python-version: "3.12"
             framework: "pyside6"

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -4,10 +4,11 @@ app_path = "{{ cookiecutter.formal_name }}.AppDir/usr/app"
 app_packages_path = "{{ cookiecutter.formal_name }}.AppDir/usr/app_packages"
 support_path = "{{ cookiecutter.formal_name }}.AppDir/usr"
 {{ {
-    "3.8": 'support_revision = "3.8.17+20230826"',
-    "3.9": 'support_revision = "3.9.18+20230826"',
-    "3.10": 'support_revision = "3.10.13+20230826"',
-    "3.11": 'support_revision = "3.11.5+20230826"',
+    "3.8": 'support_revision = "3.8.18+20231002"',
+    "3.9": 'support_revision = "3.9.18+20231002"',
+    "3.10": 'support_revision = "3.10.13+20231002"',
+    "3.11": 'support_revision = "3.11.6+20231002"',
+    "3.12": 'support_revision = "3.12.0+20231002"',
 }.get(cookiecutter.python_version|py_tag, "") }}
 # Remove the pieces of the standalone package that we don't need.
 cleanup_paths = [


### PR DESCRIPTION
Add Python 3.12 support, based on the 20231002 release of Python-build-standalone.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
