### PR TITLE
Add clang to the installed dependencies.

### DIFF
--- a/{{ cookiecutter.format }}/Dockerfile
+++ b/{{ cookiecutter.format }}/Dockerfile
@@ -38,9 +38,9 @@ RUN groupadd --non-unique --gid $HOST_GID briefcase && \
 # As root, Install system packages required by app
 ARG SYSTEM_REQUIRES
 {% if cookiecutter.vendor_base == "debian" -%}
-RUN apt-get install --no-install-recommends -y build-essential ${SYSTEM_REQUIRES}
+RUN apt-get install --no-install-recommends -y build-essential clang ${SYSTEM_REQUIRES}
 {%- else -%}
-RUN yum install -y gcc make pkgconfig ${SYSTEM_REQUIRES}
+RUN yum install -y gcc clang make pkgconfig ${SYSTEM_REQUIRES}
 {%- endif %}
 
 {% if cookiecutter.use_non_root_user -%}
@@ -48,8 +48,7 @@ RUN yum install -y gcc make pkgconfig ${SYSTEM_REQUIRES}
 USER brutus
 {%- endif %}
 
-# Configure builds so that clang isn't required, and put the Standalone Python on the build path
-ENV CC="gcc -pthread"
+# Put the Standalone Python on the build path
 ENV PATH="/app/{{ cookiecutter.formal_name }}.AppDir/usr/python/bin:${PATH}"
 
 # ========== START USER PROVIDED CONTENT ==========


### PR DESCRIPTION
Fixes beeware/briefcase#1500

Python-build-standalone has always been built with clang, but until the 20231002 release, it didn't use any CFLAGS that were clang specific. That has now changed, so we need to provide clang in the Dockerfile so that extension modules can be compiled.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
