### PR TITLE
Revert back to Standalone Python 20230826

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
         python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
         framework: [ "toga", "pyside2", "pyside6", "ppb", "pygame" ]
         exclude:
+          # PyGObject cannot be built using the current version of Standalone Python
+          # See https://github.com/indygreg/python-build-standalone/issues/194
+          - python-version: "3.12"
+            framework: "toga"
           # PySide 2 doesn't publish binary wheels that are compatible with Python 3.11+
           # and/or Ubuntu 22.04 (and is unlikely to ever do so.)
           - python-version: "3.11"

--- a/tests/apps/verify-pygame/pyproject.toml
+++ b/tests/apps/verify-pygame/pyproject.toml
@@ -13,7 +13,7 @@ description = "A Pygame test app"
 icon = "src/verify_pygame/resources/verify-pygame"
 sources = ['src/verify_pygame']
 requires = [
-    'pygame~=2.2.0',
+    'pygame~=2.5',
 ]
 
 [tool.briefcase.app.verify-pygame.linux]

--- a/tests/apps/verify-pyside2/pyproject.toml
+++ b/tests/apps/verify-pyside2/pyproject.toml
@@ -14,7 +14,7 @@ description = "A PySide2 test app"
 icon = "src/verify_pyside2/resources/verify-pyside2"
 sources = ['src/verify_pyside2']
 requires = [
-    'pyside2>=5.15.2',
+    'pyside2~=5.15',
 ]
 
 [tool.briefcase.app.verify-pyside2.linux]

--- a/tests/apps/verify-pyside6/pyproject.toml
+++ b/tests/apps/verify-pyside6/pyproject.toml
@@ -14,7 +14,7 @@ description = "A PySide6 test app"
 icon = "src/verify_pyside6/resources/verify-pyside6"
 sources = ['src/verify_pyside6']
 requires = [
-    'pyside6>=6.2.4',
+    'pyside6~=6.2',
 ]
 
 [tool.briefcase.app.verify-pyside6.linux]

--- a/tests/apps/verify-toga/pyproject.toml
+++ b/tests/apps/verify-toga/pyproject.toml
@@ -4,21 +4,21 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org/"
 license = "BSD license"
-author = 'Brutus'
+author = "Brutus"
 author_email = "contact@beeware.org"
 
 [tool.briefcase.app.verify-toga]
 formal_name = "Hello Toga"
 description = "A Toga test app"
 icon = "src/verify_toga/resources/verify-toga"
-sources = ['src/verify_toga']
+sources = ["src/verify_toga"]
 requires = [
 ]
 
-
 [tool.briefcase.app.verify-toga.linux]
 requires = [
-    'toga-gtk>=0.3.0.dev38',
+    "toga-gtk==0.3.1",
+    "PyGObject==3.44.1",
 ]
 
 [tool.briefcase.app.verify-toga.linux.appimage]
@@ -39,6 +39,6 @@ system_requires = [
     # "webkit2gtk3",
 ]
 linuxdeploy_plugins = [
-    'DEPLOY_GTK_VERSION=3 gtk',
+    "DEPLOY_GTK_VERSION=3 gtk",
 ]
 template = "../../.."

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -3,11 +3,12 @@
 app_path = "{{ cookiecutter.formal_name }}.AppDir/usr/app"
 app_packages_path = "{{ cookiecutter.formal_name }}.AppDir/usr/app_packages"
 support_path = "{{ cookiecutter.formal_name }}.AppDir/usr"
+{# using 20230826 until indygreg/python-build-standalone#194 is resolved -#}
 {{ {
-    "3.8": 'support_revision = "3.8.18+20231002"',
-    "3.9": 'support_revision = "3.9.18+20231002"',
-    "3.10": 'support_revision = "3.10.13+20231002"',
-    "3.11": 'support_revision = "3.11.6+20231002"',
+    "3.8": 'support_revision = "3.8.17+20230826"',
+    "3.9": 'support_revision = "3.9.18+20230826"',
+    "3.10": 'support_revision = "3.10.13+20230826"',
+    "3.11": 'support_revision = "3.11.5+20230826"',
     "3.12": 'support_revision = "3.12.0+20231002"',
 }.get(cookiecutter.python_version|py_tag, "") }}
 # Remove the pieces of the standalone package that we don't need.


### PR DESCRIPTION
Version 20231002 introduced a dependency on clang and is not compatible with manylinux2014

RE: https://github.com/beeware/briefcase-linux-appimage-template/pull/38#issuecomment-1776699405

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
