### PR TITLE
Revert back to Standalone Python 20230826 (0.3.16)

### DIFF
--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -3,11 +3,12 @@
 app_path = "{{ cookiecutter.formal_name }}.AppDir/usr/app"
 app_packages_path = "{{ cookiecutter.formal_name }}.AppDir/usr/app_packages"
 support_path = "{{ cookiecutter.formal_name }}.AppDir/usr"
+{# using 20230826 until indygreg/python-build-standalone#194 is resolved -#}
 {{ {
-    "3.8": 'support_revision = "3.8.18+20231002"',
-    "3.9": 'support_revision = "3.9.18+20231002"',
-    "3.10": 'support_revision = "3.10.13+20231002"',
-    "3.11": 'support_revision = "3.11.6+20231002"',
+    "3.8": 'support_revision = "3.8.17+20230826"',
+    "3.9": 'support_revision = "3.9.18+20230826"',
+    "3.10": 'support_revision = "3.10.13+20230826"',
+    "3.11": 'support_revision = "3.11.5+20230826"',
     "3.12": 'support_revision = "3.12.0+20231002"',
 }.get(cookiecutter.python_version|py_tag, "") }}
 # Remove the pieces of the standalone package that we don't need.


### PR DESCRIPTION
Version 20231002 introduced a dependency on clang and is not compatible with manylinux2014

(backport for version 0.3.16)

BRIEFCASE_REF: v0.3.16

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct