### PR TITLE
Bump Python from 20230826 to 20240107

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,3 @@ jobs:
       matrix:
         python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
         framework: [ "toga", "pyside6", "ppb", "pygame" ]
-        exclude:
-          # PyGObject cannot be built using the current version of Standalone Python
-          # See https://github.com/indygreg/python-build-standalone/issues/194
-          - python-version: "3.12"
-            framework: "toga"

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -3,13 +3,12 @@
 app_path = "{{ cookiecutter.formal_name }}.AppDir/usr/app"
 app_packages_path = "{{ cookiecutter.formal_name }}.AppDir/usr/app_packages"
 support_path = "{{ cookiecutter.formal_name }}.AppDir/usr"
-{# using 20230826 until indygreg/python-build-standalone#194 is resolved -#}
 {{ {
-    "3.8": 'support_revision = "3.8.17+20230826"',
-    "3.9": 'support_revision = "3.9.18+20230826"',
-    "3.10": 'support_revision = "3.10.13+20230826"',
-    "3.11": 'support_revision = "3.11.5+20230826"',
-    "3.12": 'support_revision = "3.12.0+20231002"',
+    "3.8": 'support_revision = "3.8.18+20240107"',
+    "3.9": 'support_revision = "3.9.18+20240107"',
+    "3.10": 'support_revision = "3.10.13+20240107"',
+    "3.11": 'support_revision = "3.11.7+20240107"',
+    "3.12": 'support_revision = "3.12.1+20231002"',
 }.get(cookiecutter.python_version|py_tag, "") }}
 # Remove the pieces of the standalone package that we don't need.
 cleanup_paths = [

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -8,7 +8,7 @@ support_path = "{{ cookiecutter.formal_name }}.AppDir/usr"
     "3.9": 'support_revision = "3.9.18+20240107"',
     "3.10": 'support_revision = "3.10.13+20240107"',
     "3.11": 'support_revision = "3.11.7+20240107"',
-    "3.12": 'support_revision = "3.12.1+20231002"',
+    "3.12": 'support_revision = "3.12.1+20240107"',
 }.get(cookiecutter.python_version|py_tag, "") }}
 # Remove the pieces of the standalone package that we don't need.
 cleanup_paths = [


### PR DESCRIPTION
## Changes
- Bump Python now that gcc compatibility is [restored](https://github.com/indygreg/python-build-standalone/issues/194).

## Notes
- https://github.com/beeware/.github/pull/79 should be merged first and this PR's CI should be re-run before merging.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct