### PR TITLE
Bump Standalone Python from 20240415 -> 20240726

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,5 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
-        framework: [ "toga", "pyside6", "pygame", "console" ]
+        # Dropped PySide6 testing since v6.6.2+ seg faults (briefcase#1908)
+        framework: [ "toga", "pygame", "console" ]

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -1,14 +1,17 @@
 # Generated using Python {{ cookiecutter.python_version }}
+[briefcase]
+target_version = "0.3.20"
+
 [paths]
 app_path = "{{ cookiecutter.formal_name }}.AppDir/usr/app"
 app_packages_path = "{{ cookiecutter.formal_name }}.AppDir/usr/app_packages"
 support_path = "{{ cookiecutter.formal_name }}.AppDir/usr"
 {{ {
-    "3.8": 'support_revision = "3.8.19+20240415"',
-    "3.9": 'support_revision = "3.9.19+20240415"',
-    "3.10": 'support_revision = "3.10.14+20240415"',
-    "3.11": 'support_revision = "3.11.9+20240415"',
-    "3.12": 'support_revision = "3.12.3+20240415"',
+    "3.8": 'support_revision = "3.8.19+20240726"',
+    "3.9": 'support_revision = "3.9.19+20240726"',
+    "3.10": 'support_revision = "3.10.14+20240726"',
+    "3.11": 'support_revision = "3.11.9+20240726"',
+    "3.12": 'support_revision = "3.12.4+20240726"',
 }.get(cookiecutter.python_version|py_tag, "") }}
 # Remove the pieces of the standalone package that we don't need.
 cleanup_paths = [


### PR DESCRIPTION
## Changes
- Use version [20240726](https://github.com/indygreg/python-build-standalone/releases/tag/20240726) of Standalone Python that includes stripped versions
- Introduces minimum platform version 0.3.20 since stripped versions of Standalone Python only exist for 20240726
- Bumps Python 3.12.3 -> 3.12.4

BRIEFCASE_REPO: https://github.com/rmartin16/briefcase
BRIEFCASE_REF: linux-stripped-python

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
