### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
         # Dropped PySide6 testing since v6.6.2+ seg faults (briefcase#1908)
         framework: [ "toga", "pygame", "console" ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,5 +39,4 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ "3.9", "3.10", "3.11", "3.12" ]
-        # Dropped PySide6 testing since v6.6.2+ seg faults (briefcase#1908)
-        framework: [ "toga", "pygame", "console" ]
+        framework: [ "toga", "pyside6", "pygame", "console" ]

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -7,7 +7,6 @@ app_path = "{{ cookiecutter.formal_name }}.AppDir/usr/app"
 app_packages_path = "{{ cookiecutter.formal_name }}.AppDir/usr/app_packages"
 support_path = "{{ cookiecutter.formal_name }}.AppDir/usr"
 {{ {
-    "3.8": 'support_revision = "3.8.19+20240726"',
     "3.9": 'support_revision = "3.9.19+20240726"',
     "3.10": 'support_revision = "3.10.14+20240726"',
     "3.11": 'support_revision = "3.11.9+20240726"',

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -7,10 +7,10 @@ app_path = "{{ cookiecutter.formal_name }}.AppDir/usr/app"
 app_packages_path = "{{ cookiecutter.formal_name }}.AppDir/usr/app_packages"
 support_path = "{{ cookiecutter.formal_name }}.AppDir/usr"
 {{ {
-    "3.9": 'support_revision = "3.9.19+20240726"',
-    "3.10": 'support_revision = "3.10.14+20240726"',
-    "3.11": 'support_revision = "3.11.9+20240726"',
-    "3.12": 'support_revision = "3.12.4+20240726"',
+    "3.9": 'support_revision = "3.9.19+20240814"',
+    "3.10": 'support_revision = "3.10.14+20240814"',
+    "3.11": 'support_revision = "3.11.9+20240814"',
+    "3.12": 'support_revision = "3.12.5+20240814"',
 }.get(cookiecutter.python_version|py_tag, "") }}
 # Remove the pieces of the standalone package that we don't need.
 cleanup_paths = [


### PR DESCRIPTION
## Changes
- Drop Python 3.8 as Briefcase's `main` branch no longer supports it
- Bump to Standalone Python 20240814

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
