### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 # Cancel active CI runs for a PR before starting another run
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 defaults:
@@ -38,5 +38,5 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
         framework: [ "toga", "pyside6", "pygame", "console" ]

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -11,6 +11,7 @@ support_path = "{{ cookiecutter.formal_name }}.AppDir/usr"
     "3.10": 'support_revision = "3.10.15+20241008"',
     "3.11": 'support_revision = "3.11.10+20241008"',
     "3.12": 'support_revision = "3.12.7+20241008"',
+    "3.13": 'support_revision = "3.13.0+20241008"',
 }.get(cookiecutter.python_version|py_tag, "") }}
 # Remove the pieces of the standalone package that we don't need.
 cleanup_paths = [

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -7,10 +7,10 @@ app_path = "{{ cookiecutter.formal_name }}.AppDir/usr/app"
 app_packages_path = "{{ cookiecutter.formal_name }}.AppDir/usr/app_packages"
 support_path = "{{ cookiecutter.formal_name }}.AppDir/usr"
 {{ {
-    "3.9": 'support_revision = "3.9.19+20240814"',
-    "3.10": 'support_revision = "3.10.14+20240814"',
-    "3.11": 'support_revision = "3.11.9+20240814"',
-    "3.12": 'support_revision = "3.12.5+20240814"',
+    "3.9": 'support_revision = "3.9.20+20241008"',
+    "3.10": 'support_revision = "3.10.15+20241008"',
+    "3.11": 'support_revision = "3.11.10+20241008"',
+    "3.12": 'support_revision = "3.12.7+20241008"',
 }.get(cookiecutter.python_version|py_tag, "") }}
 # Remove the pieces of the standalone package that we don't need.
 cleanup_paths = [


### PR DESCRIPTION
## Changes
- Use Standalone Python [20241008](https://github.com/indygreg/python-build-standalone/releases/tag/20241008) which includes Python 3.13.0

## Notes
- Manually building AppImages with Toga works on my machine

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
