### PR TITLE
Drop Python 3.9, add 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,9 @@ jobs:
       matrix:
         python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
         framework: [ "toga", "pyside6", "pygame", "console" ]
-        # Pygame hasn't published 3.14 wheels yet.
+        # Pygame and PySide6 haven't published 3.14 wheels yet.
         exclude:
+          - python-version: "3.14"
+            framework: pyside6
           - python-version: "3.14"
             framework: pygame

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,5 +38,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
         framework: [ "toga", "pyside6", "pygame", "console" ]
+        # Pygame hasn't published 3.14 wheels yet.
+        exclude:
+          - python-version: "3.14"
+            framework: pygame

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -7,11 +7,11 @@ app_path = "{{ cookiecutter.formal_name }}.AppDir/usr/app"
 app_packages_path = "{{ cookiecutter.formal_name }}.AppDir/usr/app_packages"
 support_path = "{{ cookiecutter.formal_name }}.AppDir/usr"
 {{ {
-    "3.9": 'support_revision = "3.9.22+20250409"',
-    "3.10": 'support_revision = "3.10.17+20250409"',
-    "3.11": 'support_revision = "3.11.12+20250409"',
-    "3.12": 'support_revision = "3.12.10+20250409"',
-    "3.13": 'support_revision = "3.13.3+20250409"',
+    "3.10": 'support_revision = "3.10.18+20250723"',
+    "3.11": 'support_revision = "3.11.13+20250723"',
+    "3.12": 'support_revision = "3.12.11+20250723"',
+    "3.13": 'support_revision = "3.13.5+20250723"',
+    "3.14": 'support_revision = "3.14.0rc1+20250723"',
 }.get(cookiecutter.python_version|py_tag, "") }}
 # Remove the pieces of the standalone package that we don't need.
 cleanup_paths = [


### PR DESCRIPTION
Python 3.9 is EOL; 3.14 is now available.

Needs to be updated to 3.14.0 final when Astral publishes the package.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
